### PR TITLE
Updated version of GitVersion Action

### DIFF
--- a/.github/workflows/gitversion-reusable-workflow.yml
+++ b/.github/workflows/gitversion-reusable-workflow.yml
@@ -44,10 +44,10 @@ jobs:
 
       - name: Install GitVersion
         id: install-gitversion-step
-        uses: gittools/actions/gitversion/setup@v0.9.14
+        uses: gittools/actions/gitversion/setup@v0.10.2
         with:
           versionSpec: '5.x'
         
       - name: Execute GitVersion
         id: execute-gitversion-step
-        uses: gittools/actions/gitversion/execute@v0.9.14
+        uses: gittools/actions/gitversion/execute@v0.10.2


### PR DESCRIPTION
Updated to the latest version of the `gittools/actions/gitversion` to address warnings in workflow.