### PR TITLE
Implement Conference Event Get Endpoint

### DIFF
--- a/.github/workflows/verify-code-style-reusable-workflow.yml
+++ b/.github/workflows/verify-code-style-reusable-workflow.yml
@@ -20,6 +20,9 @@ jobs:
         working-directory: ./src
         run: dotnet format PaTsa.Conference.App.Api.sln --severity info --verify-no-changes
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        
       - name: Verify Terraform Formatting
         working-directory: ./terraform
         run: terraform fmt -check

--- a/src/PaTsa.Conference.App.Api.UnitTests/Data/ConferenceEventsTestData.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/Data/ConferenceEventsTestData.cs
@@ -1,0 +1,4008 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+
+// ReSharper disable StringLiteralTypo
+
+namespace PaTsa.Conference.App.Api.UnitTests.Data;
+
+[ExcludeFromCodeCoverage]
+public class ConferenceEventsTestData : IEnumerable<object[]>
+{
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000001",
+                Location = "Online Sign Up",
+                Name = "Animatronics",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000002",
+                Location = "Winterberry",
+                Name = "Architectural Design",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000003",
+                Location = "Winterberry",
+                Name = "Biotechnology Design",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000004",
+                Location = "Winterberry",
+                Name = "Board Game Design",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000005",
+                Location = "Winterberry",
+                Name = "Children's Stories",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "TESTING",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000006",
+                Location = "Sunburst",
+                Name = "Coding",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000007",
+                Location = "Winterberry",
+                Name = "Engineering Design",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000008",
+                Location = "Winterberry",
+                Name = "Fashion Design and Technology",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "TESTING",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000009",
+                Location = "Sunburst",
+                Name = "Forensic Science",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "00000000000000000000000A",
+                Location = "Winterberry",
+                Name = "Geospatial Technology",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "00000000000000000000000B",
+                Location = "Winterberry",
+                Name = "Manufacturing Prototype",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "00000000000000000000000C",
+                Location = "Winterberry",
+                Name = "PA - Electronic Research & Exp",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "00000000000000000000000D",
+                Location = "Winterberry",
+                Name = "PA - Logo Design",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "00000000000000000000000E",
+                Location = "Winterberry",
+                Name = "PA - Materials Process",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "00000000000000000000000F",
+                Location = "Winterberry",
+                Name = "Promotional Design",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "TESTING",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000010",
+                Location = "Sunburst",
+                Name = "Technology Bowl",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000011",
+                Location = "Winterberry",
+                Name = "Transportation Modeling",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Id = "000000000000000000000012",
+                Location = "Winterberry",
+                Name = "Virtual Reality Visualization (VR)",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000013",
+                Location = "Sunburst",
+                Name = "Chapter Team",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000014",
+                Location = "Sunburst",
+                Name = "Coding",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000015",
+                Location = "Sunburst",
+                Name = "Cybersecurity",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000016",
+                Location = "Sunburst",
+                Name = "Electrical Applications",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000017",
+                Location = "Sunburst",
+                Name = "Forensic Technology",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000018",
+                Location = "Sunburst",
+                Name = "Foundations of Information Technology",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/19/2023 21:00"),
+                Id = "000000000000000000000019",
+                Location = "Sunburst",
+                Name = "Tech Bowl",
+                StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000001A",
+                Location = "Online Sign Up",
+                Name = "Debating Technological Issues",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 19:00"),
+                Id = "00000000000000000000001B",
+                Location = "Grand Ballroom",
+                Name = "Dragster Design",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000001C",
+                Location = "Online Sign Up",
+                Name = "Extemporaneous Presentation",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000001D",
+                Location = "Online Sign Up",
+                Name = "Prepared Presentation",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000001E",
+                Location = "Online Sign Up",
+                Name = "Software Development",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000001F",
+                Location = "Online Sign Up",
+                Name = "Challenging Technology Issues",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000020",
+                Location = "Online Sign Up",
+                Name = "Leadership Strategies",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000021",
+                Location = "Online Sign Up",
+                Name = "Prepared Speech",
+                StartDateTime = DateTime.Parse("4/19/2023 18:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000022",
+                Location = "Winterberry",
+                Name = "Biotechnology",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000023",
+                Location = "Winterberry",
+                Name = "Children's Stories",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000024",
+                Location = "Winterberry",
+                Name = "Construction Challenge",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000025",
+                Location = "Winterberry",
+                Name = "Data Science and Analytics",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000026",
+                Location = "Winterberry",
+                Name = "Inventions and Innovations",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000027",
+                Location = "Winterberry",
+                Name = "Mass Production",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000028",
+                Location = "Winterberry",
+                Name = "Medical Technology",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "000000000000000000000029",
+                Location = "Winterberry",
+                Name = "Microcontroller Design",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000002A",
+                Location = "Winterberry",
+                Name = "Off the Grid",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000002B",
+                Location = "Winterberry",
+                Name = "PA - Logo Design",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000002C",
+                Location = "Winterberry",
+                Name = "PA - Materials Process",
+                StartDateTime = DateTime.Parse("4/19/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000002D",
+                Location = "Grand Ballroom",
+                Name = "Drone Challenge (UAV)",
+                StartDateTime = DateTime.Parse("4/19/2023 19:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000002E",
+                Location = "Grand Ballroom",
+                Name = "Dragster",
+                StartDateTime = DateTime.Parse("4/19/2023 19:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Are you in the choir at school? Do you just sing in the shower? No matter how awful your singing is, come to the Karaoke Night special interest session where you can relieve some stress and sing along to your favorite tunes. Get the chance to compete with your friends and other students. The person with the best performance will be honored with a prize.",
+                EndDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Id = "00000000000000000000002F",
+                Location = "Exhibit Hall",
+                Name = "Karaoke Night",
+                StartDateTime = DateTime.Parse("4/19/2023 19:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Directions",
+                EndDateTime = DateTime.Parse("4/19/2023 20:15"),
+                Id = "000000000000000000000030",
+                Location = "Fox Den",
+                Name = "On Demand Video",
+                StartDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/19/2023 20:30"),
+                Id = "000000000000000000000031",
+                Location = "Ski Lodge",
+                Name = "Senior Solar Sprint",
+                StartDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Directions",
+                EndDateTime = DateTime.Parse("4/19/2023 20:15"),
+                Id = "000000000000000000000032",
+                Location = "Laurel",
+                Name = "Technical Design",
+                StartDateTime = DateTime.Parse("4/19/2023 20:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Directions",
+                EndDateTime = DateTime.Parse("4/19/2023 20:30"),
+                Id = "000000000000000000000033",
+                Location = "Fox Den",
+                Name = "PA - Digital Video Challenge",
+                StartDateTime = DateTime.Parse("4/19/2023 20:15"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Judging",
+                EndDateTime = DateTime.Parse("4/20/2023 0:00"),
+                Id = "000000000000000000000034",
+                Location = "Ski Lodge",
+                Name = "Senior Solar Sprint",
+                StartDateTime = DateTime.Parse("4/20/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Judging",
+                EndDateTime = DateTime.Parse("4/20/2023 0:00"),
+                Id = "000000000000000000000035",
+                Location = "Winterberry",
+                Name = "Virtual Reality Visualization (VR)",
+                StartDateTime = DateTime.Parse("4/20/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "TESTING",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "000000000000000000000036",
+                Location = "Snowflake",
+                Name = "Coding",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Races",
+                EndDateTime = DateTime.Parse("4/20/2023 17:00"),
+                Id = "000000000000000000000037",
+                Location = "Grand Ballroom",
+                Name = "Dragster Design",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drone Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 0:00"),
+                Id = "000000000000000000000038",
+                Location = "Grand Ballroom",
+                Name = "Drone Challenge (UAV)",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "TESTING",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "000000000000000000000039",
+                Location = "Snowflake",
+                Name = "Forensic Science",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/20/2023 10:30"),
+                Id = "00000000000000000000003A",
+                Location = "Grand Ballroom",
+                Name = "PA - R.C. Off-Road Racing",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 12:30"),
+                Id = "00000000000000000000003B",
+                Location = "Ski Lodge - 2nd Floor",
+                Name = "System Control Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "TESTING",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "00000000000000000000003C",
+                Location = "Snowflake",
+                Name = "Technology Bowl",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 11:30"),
+                Id = "00000000000000000000003D",
+                Location = "Chestnut",
+                Name = "Challenging Technology Issues",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Prep",
+                EndDateTime = DateTime.Parse("4/20/2023 11:30"),
+                Id = "00000000000000000000003E",
+                Location = "Evergreen",
+                Name = "Challenging Technology Issues",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "00000000000000000000003F",
+                Location = "Snowflake",
+                Name = "Chapter Team",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "000000000000000000000040",
+                Location = "Snowflake",
+                Name = "Coding",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "000000000000000000000041",
+                Location = "Snowflake",
+                Name = "Cybersecurity",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Races",
+                EndDateTime = DateTime.Parse("4/20/2023 17:00"),
+                Id = "000000000000000000000042",
+                Location = "Grand Ballroom",
+                Name = "Dragster",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "000000000000000000000043",
+                Location = "Snowflake",
+                Name = "Electrical Applications",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "000000000000000000000044",
+                Location = "Snowflake",
+                Name = "Forensic Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "000000000000000000000045",
+                Location = "Snowflake",
+                Name = "Foundations of Information Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Construction",
+                EndDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Id = "000000000000000000000046",
+                Location = "Ski Lodge",
+                Name = "PA - Delta Dart",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/20/2023 10:30"),
+                Id = "000000000000000000000047",
+                Location = "Grand Ballroom",
+                Name = "PA - R/C Off-Road Racing",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 12:30"),
+                Id = "000000000000000000000048",
+                Location = "Seasons #1",
+                Name = "Prepared Speech",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 12:30"),
+                Id = "000000000000000000000049",
+                Location = "Ski Lodge - 2nd Floor",
+                Name = "System Control Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "00000000000000000000004A",
+                Location = "Snowflake",
+                Name = "Tech Bowl",
+                StartDateTime = DateTime.Parse("4/20/2023 9:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Id = "00000000000000000000004B",
+                Location = "Fox Den",
+                Name = "Essays on Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 10:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "00000000000000000000004C",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Design & Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 10:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest - Outline",
+                EndDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Id = "00000000000000000000004D",
+                Location = "Fox Den",
+                Name = "Essays on Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 10:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "00000000000000000000004E",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 10:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Are you getting ready to apply for college in the fall or within the next few years? Have you already applied to college? Everyone is welcome to the college readiness special interest sessions where you can hear directly from college students and professionals who have been involved in TSA. Hear about everything from the application process to practical skills and habits to be successful as you move into your post secondary education.",
+                EndDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Id = "00000000000000000000004F",
+                Location = "Place: Matterhorn Lounge",
+                Name = "College Readiness",
+                StartDateTime = DateTime.Parse("4/20/2023 10:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Do you like parliamentary procedure? Are you a beginner looking to learn the basics? Come to the Parly Pro interest session! This session is run by the Bylaw and Resolutions Review Committee and will consist of an informational presentation as well as an activity. It will cover both beginner and advanced parliamentary procedure content in one session.",
+                EndDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Id = "000000000000000000000050",
+                Location = "Matterhorn Lounge",
+                Name = "Parly Pro (BARRC)",
+                StartDateTime = DateTime.Parse("4/20/2023 11:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Interested in learning about other chapters? Have an idea you’d like to bring to the State Officers? If you’re a chapter president, come join us for lunch! Stop by the buffet, grab some food, and look for the reserved table.",
+                EndDateTime = DateTime.Parse("4/20/2023 12:30"),
+                Id = "000000000000000000000051",
+                Location = "Exhibit Hall",
+                Name = "Chapter President’s luncheon",
+                StartDateTime = DateTime.Parse("4/20/2023 11:30"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Heats",
+                EndDateTime = DateTime.Parse("4/20/2023 14:30"),
+                Id = "000000000000000000000052",
+                Location = "Chestnut/Dogwood",
+                Name = "Debating Technological Issues",
+                StartDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pro/Con",
+                EndDateTime = DateTime.Parse("4/20/2023 14:30"),
+                Id = "000000000000000000000053",
+                Location = "Chestnut/Dogwood",
+                Name = "Debating Technological Issues",
+                StartDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Time Trials",
+                EndDateTime = DateTime.Parse("4/20/2023 13:30"),
+                Id = "000000000000000000000054",
+                Location = "Ski Lodge",
+                Name = "Senior Solar Sprint",
+                StartDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Trim/Flights - pre-built gliders",
+                EndDateTime = DateTime.Parse("4/20/2023 14:30"),
+                Id = "000000000000000000000055",
+                Location = "Grand Ballroom",
+                Name = "Flight",
+                StartDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Are you someone who loves mystery, competition, and some serious fun? Come to the escape room where you’ll have a chance to compete against other teams by solving problems and working together. It’s a great opportunity to put your skills to the test.",
+                EndDateTime = DateTime.Parse("4/20/2023 13:00"),
+                Id = "000000000000000000000056",
+                Location = "Matterhorn Lounge",
+                Name = "Escape Room",
+                StartDateTime = DateTime.Parse("4/20/2023 12:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 14:30"),
+                Id = "000000000000000000000057",
+                Location = "Chestnut",
+                Name = "Challenging Technology Issues",
+                StartDateTime = DateTime.Parse("4/20/2023 12:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000058",
+                Location = "Laurel",
+                Name = "Leadership Strategies",
+                StartDateTime = DateTime.Parse("4/20/2023 13:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Prep",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000059",
+                Location = "Fox Den",
+                Name = "Leadership Strategies",
+                StartDateTime = DateTime.Parse("4/20/2023 13:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Id = "00000000000000000000005A",
+                Location = "Seasons #1",
+                Name = "Prepared Speech",
+                StartDateTime = DateTime.Parse("4/20/2023 13:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Do you have a competitive streak? Have a need to crush your teammates in monopoly? Swing by the game room! Here you will be able to play against your friends and other TSA members in activities ranging from board games to video games. Good luck!",
+                EndDateTime = DateTime.Parse("4/20/2023 14:00"),
+                Id = "00000000000000000000005B",
+                Location = "Matterhorn Lounge",
+                Name = "Game Room",
+                StartDateTime = DateTime.Parse("4/20/2023 13:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Prep",
+                EndDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Id = "00000000000000000000005C",
+                Location = "Evergreen",
+                Name = "Challenging Technology Issues",
+                StartDateTime = DateTime.Parse("4/20/2023 13:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Judging",
+                EndDateTime = DateTime.Parse("4/20/2023 0:00"),
+                Id = "00000000000000000000005D",
+                Location = "Grand Ballroom",
+                Name = "Drone Challenge (UAV)",
+                StartDateTime = DateTime.Parse("4/20/2023 14:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 17:00"),
+                Id = "00000000000000000000005E",
+                Location = "Alpine",
+                Name = "Promotional Design",
+                StartDateTime = DateTime.Parse("4/20/2023 14:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 0:00"),
+                Id = "00000000000000000000005F",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Design & Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 14:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/20/2023 17:30"),
+                Id = "000000000000000000000060",
+                Location = "Alpine",
+                Name = "Digital Photography",
+                StartDateTime = DateTime.Parse("4/20/2023 14:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/20/2023 0:00"),
+                Id = "000000000000000000000061",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 14:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Are you looking for some competition with friends? Do you like racing? Make sure to come to the first ever State Conference Mario Kart Tournament! We’ll be hosting a bracket tournament for individuals looking to show off their skills. Make sure to bring your A game…there will be a prize for the winner!",
+                EndDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Id = "000000000000000000000062",
+                Location = "Matterhorn Lounge",
+                Name = "Mario Kart Tournament",
+                StartDateTime = DateTime.Parse("4/20/2023 14:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Presentations",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000063",
+                Location = "Winterberry",
+                Name = "Animatronics",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000064",
+                Location = "Winterberry",
+                Name = "Architectural Design",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000065",
+                Location = "Winterberry",
+                Name = "Biotechnology Design",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000066",
+                Location = "Winterberry",
+                Name = "Board Game Design",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000067",
+                Location = "Winterberry",
+                Name = "Engineering Design",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 17:30"),
+                Id = "000000000000000000000068",
+                Location = "Grand Ballroom",
+                Name = "Flight Endurance",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000069",
+                Location = "Winterberry",
+                Name = "Geospatial Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "00000000000000000000006A",
+                Location = "Winterberry",
+                Name = "Manufacturing Prototype",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "00000000000000000000006B",
+                Location = "Winterberry",
+                Name = "PA - Electronic Research & Exp",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "00000000000000000000006C",
+                Location = "Winterberry",
+                Name = "PA - Materials Process",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/20/2023 16:30"),
+                Id = "00000000000000000000006D",
+                Location = "Ski Lodge",
+                Name = "Senior Solar Sprint",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Id = "00000000000000000000006E",
+                Location = "Ski Lodge - 2nd Floor",
+                Name = "System Control Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "00000000000000000000006F",
+                Location = "Winterberry",
+                Name = "Transportation Modeling",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000070",
+                Location = "Winterberry",
+                Name = "Virtual Reality Visualization (VR)",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000071",
+                Location = "Winterberry",
+                Name = "Biotechnology",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000072",
+                Location = "Winterberry",
+                Name = "Construction Challenge",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000073",
+                Location = "Winterberry",
+                Name = "Inventions and Innovations",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000074",
+                Location = "Winterberry",
+                Name = "Mass Production",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000075",
+                Location = "Winterberry",
+                Name = "Medical Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Presentations",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000076",
+                Location = "Winterberry",
+                Name = "Microcontroller Design",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000077",
+                Location = "Winterberry",
+                Name = "Off the Grid",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000078",
+                Location = "Winterberry",
+                Name = "PA - Materials Process",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Id = "000000000000000000000079",
+                Location = "Ski Lodge - 2nd Floor",
+                Name = "System Control Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Calling all Tech Bowl enthusiasts- students, advisors, and alumni! The National Service Project Committee is hosting a Student vs. Advisors and Alumni Tech Bowl competition. This fun and informal event is a fundraiser for the American Cancer Society (ACS), so bring a donation for the ACS if you are able! Bring your team of three, or come alone!",
+                EndDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Id = "00000000000000000000007A",
+                Location = "Sunburst",
+                Name = "Advisor Tech Bowl",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Learn how business and STEM intersect through the Future for Her Business Workshop! From brainstorming your unique concepts to creating your very own business plan, this workshop will teach you how to turn your ideas into a reality. Learn business skills and new software, and unleash your entrepreneurial spirit!",
+                EndDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Id = "00000000000000000000007B",
+                Location = "Matterhorn Lounge",
+                Name = "Future for Her",
+                StartDateTime = DateTime.Parse("4/20/2023 15:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Finals",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "00000000000000000000007C",
+                Location = "Evergreen",
+                Name = "Chapter Team",
+                StartDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Holding",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "00000000000000000000007D",
+                Location = "Chestnut",
+                Name = "Chapter Team",
+                StartDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Prep",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "00000000000000000000007E",
+                Location = "Chestnut",
+                Name = "Chapter Team",
+                StartDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Id = "00000000000000000000007F",
+                Location = "Grand Ballroom",
+                Name = "Dragster Design",
+                StartDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Id = "000000000000000000000080",
+                Location = "Grand Ballroom",
+                Name = "Dragster",
+                StartDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Want to learn more about the State Officer Candidates? Come to the meet and greet! This is your chance to ask questions, learn more about campaign platforms, and talk one-on-one with each of the candidates.",
+                EndDateTime = DateTime.Parse("4/20/2023 17:00"),
+                Id = "000000000000000000000081",
+                Location = "Matterhorn Lounge",
+                Name = "Committee Meet and Greet",
+                StartDateTime = DateTime.Parse("4/20/2023 16:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000082",
+                Location = "Grand Ballroom",
+                Name = "Dragster Design",
+                StartDateTime = DateTime.Parse("4/20/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000083",
+                Location = "Grand Ballroom",
+                Name = "Dragster",
+                StartDateTime = DateTime.Parse("4/20/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Learn how business and STEM intersect through the Future for Her Business Workshop! From brainstorming your unique concepts to creating your very own business plan, this workshop will teach you how to turn your ideas into a reality. Learn business skills and new software, and unleash your entrepreneurial spirit!",
+                EndDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Id = "000000000000000000000084",
+                Location = "Matterhorn Lounge",
+                Name = "Future for Her",
+                StartDateTime = DateTime.Parse("4/20/2023 17:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "000000000000000000000085",
+                Location = "Sunburst",
+                Name = "Tech Bowl",
+                StartDateTime = DateTime.Parse("4/20/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Holding",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "000000000000000000000086",
+                Location = "Hemlock",
+                Name = "Tech Bowl",
+                StartDateTime = DateTime.Parse("4/20/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/20/2023 21:00"),
+                Id = "000000000000000000000087",
+                Location = "Alpine",
+                Name = "Coding",
+                StartDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/20/2023 18:30"),
+                Id = "000000000000000000000088",
+                Location = "Grand Ballroom",
+                Name = "Flight Endurance",
+                StartDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Set-up",
+                EndDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Id = "000000000000000000000089",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Set-up",
+                EndDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Id = "00000000000000000000008A",
+                Location = "Timberstone",
+                Name = "PA-TSA VEX - HS",
+                StartDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/20/2023 22:00"),
+                Id = "00000000000000000000008B",
+                Location = "Alpine",
+                Name = "Coding",
+                StartDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Set-up",
+                EndDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Id = "00000000000000000000008C",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Competition",
+                EndDateTime = DateTime.Parse("4/20/2023 21:00"),
+                Id = "00000000000000000000008D",
+                Location = "Timberstone",
+                Name = "PA-TSA VEX - MS",
+                StartDateTime = DateTime.Parse("4/20/2023 18:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/20/2023 21:30"),
+                Id = "00000000000000000000008E",
+                Location = "Laurel",
+                Name = "Children's Stories",
+                StartDateTime = DateTime.Parse("4/20/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/20/2023 19:30"),
+                Id = "00000000000000000000008F",
+                Location = "Evergreen",
+                Name = "Mechanical Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Sign-up",
+                EndDateTime = DateTime.Parse("4/20/2023 19:30"),
+                Id = "000000000000000000000090",
+                Location = "Evergreen",
+                Name = "Mechanical Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 18:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Finals",
+                EndDateTime = DateTime.Parse("4/20/2023 19:15"),
+                Id = "000000000000000000000091",
+                Location = "Exhibit Hall",
+                Name = "Fashion Design and Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Track Set-up",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "000000000000000000000092",
+                Location = "Grand Ballroom",
+                Name = "PA - R.C. Off-Road Racing",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Construction",
+                EndDateTime = DateTime.Parse("4/20/2023 21:30"),
+                Id = "000000000000000000000093",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Design & Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Presentations",
+                EndDateTime = DateTime.Parse("4/20/2023 21:00"),
+                Id = "000000000000000000000094",
+                Location = "Seasons #4",
+                Name = "Cybersecurity",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Prep",
+                EndDateTime = DateTime.Parse("4/20/2023 20:30"),
+                Id = "000000000000000000000095",
+                Location = "Seasons #2",
+                Name = "Data Science and Analytics",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semifinalist Construction",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "000000000000000000000096",
+                Location = "Ski Lodge",
+                Name = "Flight",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Track Set-up",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "000000000000000000000097",
+                Location = "Grand Ballroom",
+                Name = "PA - R/C Off-Road Racing",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Practice",
+                EndDateTime = DateTime.Parse("4/20/2023 21:00"),
+                Id = "000000000000000000000098",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Construction",
+                EndDateTime = DateTime.Parse("4/20/2023 21:30"),
+                Id = "000000000000000000000099",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Engineering",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Want to learn more about the State Officer Candidates? Come to the meet and greet! This is your chance to ask questions, learn more about campaign platforms, and talk one-on-one with each of the candidates.",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "00000000000000000000009A",
+                Location = "Place: Hotel Lobby",
+                Name = "Candidate Meet and Greet",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Each group in the event will be asked to go on a scavenger hunt to find answers about the Seven Springs Mountain Resort and TSA. Groups can be 1-4 people. Prizes will be awarded to the participants with the highest number of correct answers and the quickest time. Your advisor will be contacted with your prize.",
+                EndDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Id = "00000000000000000000009B",
+                Location = "Matterhorn",
+                Name = "Scavenger Hunt – Seven Springs/TSA Trivia",
+                StartDateTime = DateTime.Parse("4/20/2023 19:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Finals",
+                EndDateTime = DateTime.Parse("4/20/2023 19:45"),
+                Id = "00000000000000000000009C",
+                Location = "Winterberry",
+                Name = "Fashion Design and Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 19:15"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Presentations",
+                EndDateTime = DateTime.Parse("4/20/2023 21:00"),
+                Id = "00000000000000000000009D",
+                Location = "Seasons #1",
+                Name = "Data Science and Analytics",
+                StartDateTime = DateTime.Parse("4/20/2023 19:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Trim/Flights",
+                EndDateTime = DateTime.Parse("4/20/2023 20:30"),
+                Id = "00000000000000000000009E",
+                Location = "Grand Ballroom",
+                Name = "PA - Delta Dart",
+                StartDateTime = DateTime.Parse("4/20/2023 19:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Finals",
+                EndDateTime = DateTime.Parse("4/20/2023 21:30"),
+                Id = "00000000000000000000009F",
+                Location = "Exhibit Hall",
+                Name = "Fashion Design and Technology",
+                StartDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/20/2023 20:30"),
+                Id = "0000000000000000000000A0",
+                Location = "Timberstone",
+                Name = "PA-TSA VEX - HS",
+                StartDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Video",
+                EndDateTime = DateTime.Parse("4/20/2023 22:30"),
+                Id = "0000000000000000000000A1",
+                Location = "Sunburst",
+                Name = "Technology Bowl",
+                StartDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Holding",
+                EndDateTime = DateTime.Parse("4/20/2023 22:30"),
+                Id = "0000000000000000000000A2",
+                Location = "Hemlock",
+                Name = "Technology Bowl",
+                StartDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Check-in",
+                EndDateTime = DateTime.Parse("4/20/2023 20:30"),
+                Id = "0000000000000000000000A3",
+                Location = "Ski Lodge",
+                Name = "Junior Solar Sprint",
+                StartDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Come check out the Jeopardy trivia night special interest session! We'll be competing in teams. If you have a team that you want to work with, that's great! But if you don't, we will find you a team! Trivia night will be conducted in a Jeopardy style format. We're excited to see all of you there! This… Is… Jeopardy!",
+                EndDateTime = DateTime.Parse("4/20/2023 21:00"),
+                Id = "0000000000000000000000A4",
+                Location = "Snowflake",
+                Name = "Jeopardy Trivia Night – State Officer Team",
+                StartDateTime = DateTime.Parse("4/20/2023 20:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Practice",
+                EndDateTime = DateTime.Parse("4/20/2023 22:00"),
+                Id = "0000000000000000000000A5",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/20/2023 20:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Practice",
+                EndDateTime = DateTime.Parse("4/20/2023 22:00"),
+                Id = "0000000000000000000000A6",
+                Location = "Timberstone",
+                Name = "PA-TSA VEX - HS",
+                StartDateTime = DateTime.Parse("4/20/2023 20:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Come and listen to the PA TSA State Officer Candidates speeches about why they want to \"Be Your Next State Officer.\" Speeches will be viewed as a group and if time allows, a live Q&A will occur where you can ask the candidates your questions. Two representatives must be present to be able to vote for your chapter.",
+                EndDateTime = DateTime.Parse("4/20/2023 23:00"),
+                Id = "0000000000000000000000A7",
+                Location = "Exhibit Hall",
+                Name = "State Officer Candidate Speeches",
+                StartDateTime = DateTime.Parse("4/20/2023 21:30"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Come learn more about joining PA-TSA’s active alumni association.",
+                EndDateTime = DateTime.Parse("4/20/2023 23:00"),
+                Id = "0000000000000000000000A8",
+                Location = "Sunburst",
+                Name = "Alumni Meeting – open to all graduating seniors and current TSA alumni",
+                StartDateTime = DateTime.Parse("4/20/2023 22:30"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Set-up",
+                EndDateTime = DateTime.Parse("4/21/2023 7:45"),
+                Id = "0000000000000000000000A9",
+                Location = "Alpine",
+                Name = "Computer-Aided Design (CAD) Architecture",
+                StartDateTime = DateTime.Parse("4/21/2023 7:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Set-up",
+                EndDateTime = DateTime.Parse("4/21/2023 7:45"),
+                Id = "0000000000000000000000AA",
+                Location = "Alpine",
+                Name = "Computer-Aided Design (CAD) Engineering",
+                StartDateTime = DateTime.Parse("4/21/2023 7:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Set-up",
+                EndDateTime = DateTime.Parse("4/21/2023 7:45"),
+                Id = "0000000000000000000000AB",
+                Location = "Alpine",
+                Name = "Computer-Aided Design Foundations",
+                StartDateTime = DateTime.Parse("4/21/2023 7:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 11:30"),
+                Id = "0000000000000000000000AC",
+                Location = "Alpine",
+                Name = "Computer-Aided Design (CAD) Engineering",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 11:30"),
+                Id = "0000000000000000000000AD",
+                Location = "Seasons #2",
+                Name = "Extemporaneous Presentation",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Holding",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000AE",
+                Location = "Sunburst",
+                Name = "Extemporaneous Presentation",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Prep",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000AF",
+                Location = "Snowflake",
+                Name = "Extemporaneous Presentation",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Races",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000B0",
+                Location = "Grand Ballroom",
+                Name = "PA - R.C. Off-Road Racing",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/21/2023 8:30"),
+                Id = "0000000000000000000000B1",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/21/2023 8:30"),
+                Id = "0000000000000000000000B2",
+                Location = "Timberstone",
+                Name = "PA-TSA VEX - HS",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 11:30"),
+                Id = "0000000000000000000000B3",
+                Location = "Seasons #3",
+                Name = "Prepared Presentation",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Holding",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000B4",
+                Location = "Sunburst",
+                Name = "Prepared Presentation",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 11:30"),
+                Id = "0000000000000000000000B5",
+                Location = "Alpine",
+                Name = "Computer-Aided Design Foundations",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Races",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000B6",
+                Location = "Grand Ballroom",
+                Name = "PA - R/C Off-Road Racing",
+                StartDateTime = DateTime.Parse("4/21/2023 8:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Entry submission",
+                EndDateTime = DateTime.Parse("4/21/2023 9:30"),
+                Id = "0000000000000000000000B7",
+                Location = "Online Submission",
+                Name = "On Demand Video",
+                StartDateTime = DateTime.Parse("4/21/2023 8:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 11:00"),
+                Id = "0000000000000000000000B8",
+                Location = "Exhibit Hall - Annex",
+                Name = "Mechanical Engineering",
+                StartDateTime = DateTime.Parse("4/21/2023 8:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Entry submission",
+                EndDateTime = DateTime.Parse("4/21/2023 9:30"),
+                Id = "0000000000000000000000B9",
+                Location = "Online Submission",
+                Name = "PA - Digital Video Challenge",
+                StartDateTime = DateTime.Parse("4/21/2023 8:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Entry submission",
+                EndDateTime = DateTime.Parse("4/21/2023 9:30"),
+                Id = "0000000000000000000000BA",
+                Location = "Online Submission",
+                Name = "Technical Design",
+                StartDateTime = DateTime.Parse("4/21/2023 8:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Presentation",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000BB",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Audio Podcasting",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000BC",
+                Location = "Chestnut",
+                Name = "Children's Stories",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Holding",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000BD",
+                Location = "Chestnut",
+                Name = "Children's Stories",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000BE",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Data Science and Analytics",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000BF",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Digital Video Production",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 11:00"),
+                Id = "0000000000000000000000C0",
+                Location = "Hemlock",
+                Name = "Drone Challenge (UAV)",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C1",
+                Location = "Fox Den",
+                Name = "Future Technology & Engineering Teacher",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C2",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Music Production",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Competition",
+                EndDateTime = DateTime.Parse("4/21/2023 10:30"),
+                Id = "0000000000000000000000C3",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Presentations",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C4",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Software Development",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C5",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Video Game Design",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C6",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Webmaster",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C7",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Career Prep",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C8",
+                Location = "Dogwood",
+                Name = "Chapter Team",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000C9",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Community Service Video",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/21/2023 11:00"),
+                Id = "0000000000000000000000CA",
+                Location = "Laurel",
+                Name = "Promotional Marketing",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Presentation",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000CB",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "STEM Animation",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000CC",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Video Game Design",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Interviews",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000CD",
+                Location = "Ski Lodge - Foggy Brews",
+                Name = "Website Design",
+                StartDateTime = DateTime.Parse("4/21/2023 9:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000CE",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Design & Engineering",
+                StartDateTime = DateTime.Parse("4/21/2023 10:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Testing",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000CF",
+                Location = "Ski Lodge - Maple",
+                Name = "Structural Engineering",
+                StartDateTime = DateTime.Parse("4/21/2023 10:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Trying to find the right fit college can be an intimidating process, but by asking yourself some simple questions you’ll discover your home away from home in no time.",
+                EndDateTime = DateTime.Parse("4/21/2023 11:00"),
+                Id = "0000000000000000000000D0",
+                Location = "Matterhorn Lounge",
+                Name = "Finding Your College: 10 Questions to Help You Think Deeply and Act Boldly",
+                StartDateTime = DateTime.Parse("4/21/2023 10:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Competition",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000D1",
+                Location = "Timberstone",
+                Name = "PA-TSA VEX - HS",
+                StartDateTime = DateTime.Parse("4/21/2023 10:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Time Trials",
+                EndDateTime = DateTime.Parse("4/21/2023 12:30"),
+                Id = "0000000000000000000000D2",
+                Location = "Ski Lodge",
+                Name = "Junior Solar Sprint",
+                StartDateTime = DateTime.Parse("4/21/2023 11:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "A presentation which shows the process and nuclear science behind starting up Penn State’s Breazeale Nuclear Reactor. Students will be able to engage with interactive elements such hands-on simulations of the reactor, and directly communicate with reactor operators aiding them in startup process",
+                EndDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Id = "0000000000000000000000D3",
+                Location = "Matterhorn Lounge",
+                Name = "How to Start a Nuclear Reactor",
+                StartDateTime = DateTime.Parse("4/21/2023 11:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "PDE Technology & Engineering Content Advisor Brandt Hutzel will discuss the new Technology & Engineering Standards that are part of the STEELS standards suite. In addition, he will share information on the STEP w/EbD Initiative that will support the implementation of the new standards during the next three years.",
+                EndDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Id = "0000000000000000000000D4",
+                Location = "Matterhorn Lounge",
+                Name = "New Technology & Engineering Standards, Brandt Hutzel",
+                StartDateTime = DateTime.Parse("4/21/2023 12:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000D5",
+                Location = "Alpine",
+                Name = "Computer-Aided Design (CAD) Architecture",
+                StartDateTime = DateTime.Parse("4/21/2023 12:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals - Essay",
+                EndDateTime = DateTime.Parse("4/21/2023 14:30"),
+                Id = "0000000000000000000000D6",
+                Location = "Fox Den",
+                Name = "Essays on Technology",
+                StartDateTime = DateTime.Parse("4/21/2023 12:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000D7",
+                Location = "Seasons #2",
+                Name = "Extemporaneous Presentation",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Id = "0000000000000000000000D8",
+                Location = "Dogwood",
+                Name = "Forensic Science",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals - report write-up",
+                EndDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Id = "0000000000000000000000D9",
+                Location = "Evergreen",
+                Name = "Forensic Science",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Construction",
+                EndDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Id = "0000000000000000000000DA",
+                Location = "Laurel",
+                Name = "Photographic Technology",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000DB",
+                Location = "Seasons #3",
+                Name = "Prepared Presentation",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Id = "0000000000000000000000DC",
+                Location = "Chestnut",
+                Name = "Forensic Technology",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals - report write-up",
+                EndDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Id = "0000000000000000000000DD",
+                Location = "Evergreen",
+                Name = "Forensic Technology",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Drop-off",
+                EndDateTime = DateTime.Parse("4/21/2023 13:30"),
+                Id = "0000000000000000000000DE",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Do you have an interest or considering a career in software development? Learn what it is like to be one from someone who has been developing software for over 15 years.",
+                EndDateTime = DateTime.Parse("4/21/2023 14:00"),
+                Id = "0000000000000000000000DF",
+                Location = "Matterhorn Lounge",
+                Name = "Day in the Life of a Developer, TJ Cappelletti",
+                StartDateTime = DateTime.Parse("4/21/2023 13:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Id = "0000000000000000000000E0",
+                Location = "Ski Lodge",
+                Name = "Technology Problem Solving",
+                StartDateTime = DateTime.Parse("4/21/2023 13:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Contest",
+                EndDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Id = "0000000000000000000000E1",
+                Location = "Ski Lodge - 2nd Floor",
+                Name = "Problem Solving",
+                StartDateTime = DateTime.Parse("4/21/2023 13:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Trim/Flights - semifinalists",
+                EndDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Id = "0000000000000000000000E2",
+                Location = "Grand Ballroom",
+                Name = "Flight",
+                StartDateTime = DateTime.Parse("4/21/2023 14:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/21/2023 15:30"),
+                Id = "0000000000000000000000E3",
+                Location = "Ski Lodge",
+                Name = "Junior Solar Sprint",
+                StartDateTime = DateTime.Parse("4/21/2023 14:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Competition",
+                EndDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Id = "0000000000000000000000E4",
+                Location = "Timberstone",
+                Name = "PA - Robotics",
+                StartDateTime = DateTime.Parse("4/21/2023 14:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Come to the Minecraft special interest session where you can play survival or creative Minecraft with your friends and TSA peers. There will be a Build Battle event in which competitors will build a TSA-themed work that will be judged by a State Officer. The winner will receive a prize. A personal device is required with Minecraft that can run offline.",
+                EndDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Id = "0000000000000000000000E5",
+                Location = "Matterhorn Lounge",
+                Name = "Minecraft Tournament",
+                StartDateTime = DateTime.Parse("4/21/2023 14:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Finals",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000E6",
+                Location = "Seasons #1",
+                Name = "Debating Technological Issues",
+                StartDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Holding",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000E7",
+                Location = "Sunburst",
+                Name = "Debating Technological Issues",
+                StartDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pro/Con",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000E8",
+                Location = "Seasons #2",
+                Name = "Debating Technological Issues",
+                StartDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finalist Presentation",
+                EndDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Id = "0000000000000000000000E9",
+                Location = "Laurel",
+                Name = "Photographic Technology",
+                StartDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "How well do you work under pressure? In this year’s Minute to Win It, participants will compete in numerous minute-long challenges ranging from relay races, stacking cards, jelly bean tossing, and more. The participant who wins the most number of challenges will leave the session with a prize!",
+                EndDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Id = "0000000000000000000000EA",
+                Location = "Matterhorn Lounge",
+                Name = "Minute to Win It",
+                StartDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Semi-finals",
+                EndDateTime = DateTime.Parse("4/21/2023 16:30"),
+                Id = "0000000000000000000000EB",
+                Location = "Fox Den",
+                Name = "Electrical Applications",
+                StartDateTime = DateTime.Parse("4/21/2023 15:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick Up",
+                EndDateTime = DateTime.Parse("4/21/2023 16:30"),
+                Id = "0000000000000000000000EC",
+                Location = "Grand Ballroom",
+                Name = "PA - R/C Off-Road Racing",
+                StartDateTime = DateTime.Parse("4/21/2023 15:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description =
+                    "Do you love the tech problem solving competition? Did you not get an opportunity to compete in states for it, but still want to have an awesome time building things to solve a problem? Then this special interest session is for you!! Come join us for a lot of fun and get some tech problem solving done!!!",
+                EndDateTime = DateTime.Parse("4/21/2023 15:00"),
+                Id = "0000000000000000000000ED",
+                Location = "Matterhorn Lounge",
+                Name = "Mini Tech Problem Solving",
+                StartDateTime = DateTime.Parse("4/21/2023 16:00"),
+                Type = "Special Interest"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 18:00"),
+                Id = "0000000000000000000000EE",
+                Location = "Alpine",
+                Name = "Computer-Aided Design (CAD) Architecture",
+                StartDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 18:00"),
+                Id = "0000000000000000000000EF",
+                Location = "Alpine",
+                Name = "Computer-Aided Design (CAD) Engineering",
+                StartDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 18:00"),
+                Id = "0000000000000000000000F0",
+                Location = "Alpine",
+                Name = "Computer-Aided Design Foundations",
+                StartDateTime = DateTime.Parse("4/21/2023 17:00"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F1",
+                Location = "Winterberry",
+                Name = "Animatronics",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F2",
+                Location = "Winterberry",
+                Name = "Architectural Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F3",
+                Location = "Winterberry",
+                Name = "Biotechnology Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F4",
+                Location = "Winterberry",
+                Name = "Board Game Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F5",
+                Location = "Winterberry",
+                Name = "Children's Stories",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F6",
+                Location = "Winterberry",
+                Name = "Engineering Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F7",
+                Location = "Winterberry",
+                Name = "Manufacturing Prototype",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F8",
+                Location = "Winterberry",
+                Name = "PA - Electronic Research & Exp",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000F9",
+                Location = "Winterberry",
+                Name = "PA - Logo Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000FA",
+                Location = "Winterberry",
+                Name = "PA - Materials Process",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000FB",
+                Location = "Winterberry",
+                Name = "Promotional Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000FC",
+                Location = "Winterberry",
+                Name = "Transportation Modeling",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000FD",
+                Location = "Winterberry",
+                Name = "Virtual Reality Visualization (VR)",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "High School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000FE",
+                Location = "Winterberry",
+                Name = "Biotechnology",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "0000000000000000000000FF",
+                Location = "Winterberry",
+                Name = "Children's Stories",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000100",
+                Location = "Winterberry",
+                Name = "Construction Challenge",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000101",
+                Location = "Winterberry",
+                Name = "Data Science and Analytics",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick Up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000102",
+                Location = "Winterberry",
+                Name = "Inventions and Innovations",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000103",
+                Location = "Winterberry",
+                Name = "Mass Production",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000104",
+                Location = "Winterberry",
+                Name = "Medical Technology",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000105",
+                Location = "Winterberry",
+                Name = "Microcontroller Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000106",
+                Location = "Winterberry",
+                Name = "Off the Grid",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000107",
+                Location = "Winterberry",
+                Name = "PA - Logo Design",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new ConferenceEvent
+            {
+                Description = "Pick-up",
+                EndDateTime = DateTime.Parse("4/21/2023 19:00"),
+                Id = "000000000000000000000108",
+                Location = "Winterberry",
+                Name = "PA - Materials Process",
+                StartDateTime = DateTime.Parse("4/21/2023 17:30"),
+                Type = "Middle School"
+            },
+            ConferenceEventDataIssues.None
+        };
+    }
+}
+
+[Flags]
+public enum ConferenceEventDataIssues
+{
+    None = 0
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/ExtensionMethods/FilterDefinitionExtensions.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/ExtensionMethods/FilterDefinitionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+
+namespace PaTsa.Conference.App.Api.UnitTests.ExtensionMethods;
+
+[ExcludeFromCodeCoverage]
+public static class FilterDefinitionExtensions
+{
+    public static string RenderToJson<TDocument>(this FilterDefinition<TDocument> filter)
+    {
+        var serializerRegistry = BsonSerializer.SerializerRegistry;
+        var documentSerializer = serializerRegistry.GetSerializer<TDocument>();
+        return filter.Render(documentSerializer, serializerRegistry).ToJson();
+    }
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/Helpers/ConferenceEventEqualityComparer.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/Helpers/ConferenceEventEqualityComparer.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+
+namespace PaTsa.Conference.App.Api.UnitTests.Helpers;
+
+[ExcludeFromCodeCoverage]
+internal class ConferenceEventEqualityComparer : IEqualityComparer<ConferenceEvent?>, IEqualityComparer<IList<ConferenceEvent>?>
+{
+    public bool Equals(ConferenceEvent? x, ConferenceEvent? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+
+        var descriptionsMatch = x.Description == y.Description;
+        var endDateTimesMatch = x.EndDateTime == y.EndDateTime;
+        var idsMatch = x.Id == y.Id;
+        var locationsMatch = x.Location == y.Location;
+        var namesMatch = x.Name == y.Name;
+        var startDateTimesMatch = x.StartDateTime == y.StartDateTime;
+        var typesMatch = x.Type == y.Type;
+
+        return descriptionsMatch &&
+               endDateTimesMatch &&
+               idsMatch &&
+               locationsMatch &&
+               namesMatch &&
+               startDateTimesMatch &&
+               typesMatch;
+    }
+
+    public bool Equals(IList<ConferenceEvent>? x, IList<ConferenceEvent>? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+        if (x.Count != y.Count) return false;
+
+        foreach (var leftConferenceEvent in x)
+        {
+            var rightConferenceEvent = y.SingleOrDefault(_ => _.Id == leftConferenceEvent.Id);
+
+            if (!Equals(leftConferenceEvent, rightConferenceEvent)) return false;
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(ConferenceEvent? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+
+    public int GetHashCode(IList<ConferenceEvent>? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/Helpers/ConferenceEventModelEqualityComparer.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/Helpers/ConferenceEventModelEqualityComparer.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using PaTsa.Conference.App.Api.WebApi.Models;
+
+namespace PaTsa.Conference.App.Api.UnitTests.Helpers;
+
+[ExcludeFromCodeCoverage]
+internal class ConferenceEventModelEqualityComparer : IEqualityComparer<ConferenceEventModel?>, IEqualityComparer<IList<ConferenceEventModel>?>
+{
+    public bool Equals(ConferenceEventModel? x, ConferenceEventModel? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+
+        var descriptionsMatch = x.Description == y.Description;
+        var endDateTimesMatch = x.EndDateTime == y.EndDateTime;
+        var idsMatch = x.Id == y.Id;
+        var locationsMatch = x.Location == y.Location;
+        var namesMatch = x.Name == y.Name;
+        var startDateTimesMatch = x.StartDateTime == y.StartDateTime;
+        var typesMatch = x.Type == y.Type;
+
+        return descriptionsMatch &&
+               endDateTimesMatch &&
+               idsMatch &&
+               locationsMatch &&
+               namesMatch &&
+               startDateTimesMatch &&
+               typesMatch;
+    }
+
+    public bool Equals(IList<ConferenceEventModel>? x, IList<ConferenceEventModel>? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+        if (x.Count != y.Count) return false;
+
+        foreach (var leftConferenceEvent in x)
+        {
+            var rightConferenceEvent = y.SingleOrDefault(_ => _.Id == leftConferenceEvent.Id);
+
+            if (!Equals(leftConferenceEvent, rightConferenceEvent)) return false;
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(ConferenceEventModel? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+
+    public int GetHashCode(IList<ConferenceEventModel>? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/ConferenceEventsControllerTests.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/ConferenceEventsControllerTests.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using PaTsa.Conference.App.Api.UnitTests.Data;
+using PaTsa.Conference.App.Api.UnitTests.Helpers;
+using PaTsa.Conference.App.Api.WebApi.Controllers;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+using PaTsa.Conference.App.Api.WebApi.Services;
+using Xunit;
+
+namespace PaTsa.Conference.App.Api.UnitTests.WebApi.Controllers;
+
+[ExcludeFromCodeCoverage]
+public class ConferenceEventsControllerTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Public_Methods_Should_Have_Http_Method_Attribute()
+    {
+        var conferenceEventsControllerType = typeof(ConferenceEventsController);
+
+        var methodInfos = conferenceEventsControllerType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+
+        Assert.NotEmpty(methodInfos);
+
+        foreach (var methodInfo in methodInfos)
+        {
+            // Needs to be nullable so the compiler sees it's initialized
+            // The Assert.Fail doesn't tell it that the line it's being used
+            // will only ever be hit if it's initialized
+            Type? attributeType = null;
+
+            switch (methodInfo.Name.ToLower())
+            {
+                case "delete":
+                    attributeType = typeof(HttpDeleteAttribute);
+                    break;
+                case "get":
+                    attributeType = typeof(HttpGetAttribute);
+                    break;
+                case "head":
+                    attributeType = typeof(HttpHeadAttribute);
+                    break;
+                case "options":
+                    attributeType = typeof(HttpOptionsAttribute);
+                    break;
+                case "patch":
+                    attributeType = typeof(HttpPatchAttribute);
+                    break;
+                case "post":
+                    attributeType = typeof(HttpPostAttribute);
+                    break;
+                case "put":
+                    attributeType = typeof(HttpPutAttribute);
+                    break;
+                default:
+                    Assert.Fail("Unsupported public HTTP operation");
+                    break;
+            }
+
+            var attributes = methodInfo.GetCustomAttributes(attributeType, false);
+
+            Assert.NotNull(attributes);
+            Assert.NotEmpty(attributes);
+            Assert.Single(attributes);
+        }
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Should_Have_ApiController_Attribute()
+    {
+        var conferenceEventsControllerType = typeof(ConferenceEventsController);
+
+        var attributes = conferenceEventsControllerType.GetCustomAttributes(typeof(ApiControllerAttribute), false);
+
+        Assert.NotNull(attributes);
+        Assert.NotEmpty(attributes);
+        Assert.Single(attributes);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Should_Have_Produces_Attribute()
+    {
+        var conferenceEventsControllerType = typeof(ConferenceEventsController);
+
+        var attributes = conferenceEventsControllerType.GetCustomAttributes(typeof(ProducesAttribute), false);
+
+        Assert.NotNull(attributes);
+        Assert.NotEmpty(attributes);
+        Assert.Single(attributes);
+
+        var producesAttribute = (ProducesAttribute)attributes[0];
+
+        Assert.Contains("application/json", producesAttribute.ContentTypes);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Should_Have_Route_Attribute()
+    {
+        var conferenceEventsControllerType = typeof(ConferenceEventsController);
+
+        var attributes = conferenceEventsControllerType.GetCustomAttributes(typeof(RouteAttribute), false);
+
+        Assert.NotNull(attributes);
+        Assert.NotEmpty(attributes);
+        Assert.Single(attributes);
+
+        var routeAttribute = (RouteAttribute)attributes[0];
+
+        Assert.Equal("api/[controller]", routeAttribute.Template);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_With_Default_PageNumber_And_PageSize()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var conferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .ToList();
+
+        var mockedConferenceEventsService = new Mock<IConferenceEventsService>();
+        mockedConferenceEventsService
+            .Setup(_ => _.GetAsync(default))
+            .ReturnsAsync(conferenceEvents);
+
+        var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
+
+        // Act
+        var actionResult = await conferenceEventsController.Get();
+
+        Assert.NotNull(actionResult);
+
+        var conferenceEventModels = actionResult.Value;
+        Assert.NotNull(conferenceEventModels);
+        Assert.NotEmpty(conferenceEventModels);
+        Assert.Equal(25, conferenceEventModels.Count);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_With_Results_Paged()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var pageNumber = 2;
+        var pageSize = 20;
+
+        var conferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .ToList();
+
+        var pagedConferenceEventModels = conferenceEvents
+            .ToModels()
+            // This is the logic
+            // But since we hard coded pageNumber to 2
+            // Optimizer doesn't like this statement
+            //.Skip((pageNumber - 1) * pageSize)
+            .Skip(pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        var mockedConferenceEventsService = new Mock<IConferenceEventsService>();
+        mockedConferenceEventsService
+            .Setup(_ => _.GetAsync(default))
+            .ReturnsAsync(conferenceEvents);
+
+        var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
+
+        // Act
+        var actionResult = await conferenceEventsController.Get(pageNumber, pageSize);
+
+        Assert.NotNull(actionResult);
+
+        var conferenceEventModels = actionResult.Value;
+        Assert.NotNull(conferenceEventModels);
+        Assert.Equal(pagedConferenceEventModels, conferenceEventModels, new ConferenceEventModelEqualityComparer());
+    }
+
+    [Theory]
+    [InlineData(5, 1, 10)]
+    [InlineData(10, 2, 10)]
+    [InlineData(30, 2, 10)]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_Regardless_Of_Pagination(int take, int pageNumber, int pageSize)
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var conferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .Take(take)
+            .ToList();
+
+        var mockedConferenceEventsService = new Mock<IConferenceEventsService>();
+        mockedConferenceEventsService
+            .Setup(_ => _.GetAsync(default))
+            .ReturnsAsync(conferenceEvents);
+
+        var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
+
+        // Act
+        var actionResult = await conferenceEventsController.Get(pageNumber, pageSize);
+
+        Assert.NotNull(actionResult);
+
+        var conferenceEventModels = actionResult.Value;
+        Assert.NotNull(conferenceEventModels);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_When_Empty()
+    {
+        // Arrange
+        var mockedConferenceEventsService = new Mock<IConferenceEventsService>();
+        mockedConferenceEventsService
+            .Setup(_ => _.GetAsync(default))
+            .ReturnsAsync(new List<ConferenceEvent>(0));
+
+        var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
+
+        // Act
+        var actionResult = await conferenceEventsController.Get();
+
+        Assert.NotNull(actionResult);
+
+        var conferenceEventModels = actionResult.Value;
+        Assert.NotNull(conferenceEventModels);
+        Assert.Empty(conferenceEventModels);
+    }
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/StatusControllerTests.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/StatusControllerTests.cs
@@ -244,7 +244,7 @@ public class StatusControllerTests
         Assert.NotEmpty(attributes);
         Assert.Single(attributes);
 
-        var producesAttribute = (ProducesAttribute) attributes[0];
+        var producesAttribute = (ProducesAttribute)attributes[0];
 
         Assert.Contains("application/json", producesAttribute.ContentTypes);
     }
@@ -261,7 +261,7 @@ public class StatusControllerTests
         Assert.NotEmpty(attributes);
         Assert.Single(attributes);
 
-        var routeAttribute = (RouteAttribute) attributes[0];
+        var routeAttribute = (RouteAttribute)attributes[0];
 
         Assert.Equal("api/[controller]", routeAttribute.Template);
     }

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/StatusControllerTests.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/StatusControllerTests.cs
@@ -17,7 +17,7 @@ public class StatusControllerTests
 {
     private static void AssertServiceStatus(ServicesStatusModel servicesStatusModel, PingableServiceFailures pingableServiceFailures)
     {
-        throw new NotImplementedException();
+        Assert.Equal(servicesStatusModel.ConferenceEventsServiceIsAlive, !pingableServiceFailures.HasFlag(PingableServiceFailures.ConferenceEvents));
     }
 
     private static IList<IPingableService> BuildHealthyPingableServices()
@@ -94,7 +94,7 @@ public class StatusControllerTests
 
     #region Inline Data
 
-    [InlineData(PingableServiceFailures.None)]
+    [InlineData(PingableServiceFailures.ConferenceEvents)]
 
     #endregion
 
@@ -130,7 +130,7 @@ public class StatusControllerTests
 
     #region Inline Data
 
-    [InlineData(PingableServiceFailures.None)]
+    [InlineData(PingableServiceFailures.ConferenceEvents)]
 
     #endregion
 
@@ -165,7 +165,7 @@ public class StatusControllerTests
 
     private static Type[] GetServiceTypes()
     {
-        return Type.EmptyTypes;
+        return new[] { typeof(ConferenceEventsService) };
     }
 
     [Fact]
@@ -334,7 +334,8 @@ public class StatusControllerTests
 [Flags]
 public enum PingableServiceFailures
 {
-    None = 0
+    None = 0,
+    ConferenceEvents = 1 << 0
 }
 
 public enum ServiceFailureType

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using PaTsa.Conference.App.Api.UnitTests.Data;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+using Xunit;
+
+namespace PaTsa.Conference.App.Api.UnitTests.WebApi.Entities;
+
+[ExcludeFromCodeCoverage]
+public class EntityExtensionsTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToModel_For_ConferenceEvent_Should_Return_ConferenceEventModel()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var conferenceEvent = conferenceEventsTestData
+            .First(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)[0] as ConferenceEvent;
+
+        Assert.NotNull(conferenceEvent);
+
+        // Act
+        var conferenceEventModel = conferenceEvent.ToModel();
+
+        // Assert
+        Assert.Equal(conferenceEvent.Description, conferenceEventModel.Description);
+        Assert.Equal(conferenceEvent.EndDateTime, conferenceEventModel.EndDateTime);
+        Assert.Equal(conferenceEvent.Id, conferenceEventModel.Id);
+        Assert.Equal(conferenceEvent.Location, conferenceEventModel.Location);
+        Assert.Equal(conferenceEvent.Name, conferenceEventModel.Name);
+        Assert.Equal(conferenceEvent.StartDateTime, conferenceEventModel.StartDateTime);
+        Assert.Equal(conferenceEvent.Type, conferenceEventModel.Type);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToModels_For_List_Of_ConferenceEvent_Should_Return_List_Of_ConferenceEventModel()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var conferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Take(5)
+            .Select(_ => _[0] as ConferenceEvent)
+            .Cast<ConferenceEvent>()
+            .ToList();
+
+        // Act
+        var conferenceEventModels = conferenceEvents.ToModels();
+
+        Assert.Equal(conferenceEvents.Count, conferenceEventModels.Count);
+
+        // Assert
+        foreach (var conferenceEventModel in conferenceEventModels)
+        {
+            Assert.NotNull(conferenceEventModel);
+
+            var conferenceEvent = conferenceEvents.SingleOrDefault(_ => _.Id == conferenceEventModel.Id);
+
+            Assert.NotNull(conferenceEvent);
+
+            Assert.Equal(conferenceEvent.Description, conferenceEventModel.Description);
+            Assert.Equal(conferenceEvent.EndDateTime, conferenceEventModel.EndDateTime);
+            Assert.Equal(conferenceEvent.Location, conferenceEventModel.Location);
+            Assert.Equal(conferenceEvent.Name, conferenceEventModel.Name);
+            Assert.Equal(conferenceEvent.StartDateTime, conferenceEventModel.StartDateTime);
+            Assert.Equal(conferenceEvent.Type, conferenceEventModel.Type);
+        }
+    }
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Models/ApiErrorModelTests.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Models/ApiErrorModelTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using PaTsa.Conference.App.Api.WebApi.Models;
+using Xunit;
+
+namespace PaTsa.Conference.App.Api.UnitTests.WebApi.Models;
+
+[ExcludeFromCodeCoverage]
+public class ApiErrorModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Unauthorized_Should_Return_ApiErrorResponse_For_Unauthorized()
+    {
+        // Arrange
+        // Act
+        var apiErrorModel = ApiErrorModel.Unauthorized;
+
+        // Assert
+        Assert.Equal((int)ErrorCodes.Unauthorized, apiErrorModel.ErrorCode);
+        Assert.Equal("Client is unauthorized", apiErrorModel.Message);
+    }
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Models/ModelExtensionsTests.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Models/ModelExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using PaTsa.Conference.App.Api.WebApi.Models;
+using Xunit;
+
+namespace PaTsa.Conference.App.Api.UnitTests.WebApi.Models;
+
+[ExcludeFromCodeCoverage]
+public class ModelExtensionsTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToEntity_For_ConferenceEventModel_Should_Return_ConferenceEvent()
+    {
+        // Arrange
+        var conferenceEventModel = new ConferenceEventModel
+        {
+            Description = "Sign-up",
+            EndDateTime = DateTime.Parse("4/19/2023 18:30"),
+            Id = "000000000000000000000001",
+            Location = "Online Sign Up",
+            Name = "Animatronics",
+            StartDateTime = DateTime.Parse("4/19/2023 17:00"),
+            Type = "High School"
+        };
+
+        Assert.NotNull(conferenceEventModel);
+
+        // Act
+        var conferenceEvent = conferenceEventModel.ToEntity();
+
+        // Assert
+        Assert.Equal(conferenceEventModel.Description, conferenceEvent.Description);
+        Assert.Equal(conferenceEventModel.EndDateTime, conferenceEvent.EndDateTime);
+        Assert.Equal(conferenceEventModel.Id, conferenceEvent.Id);
+        Assert.Equal(conferenceEventModel.Location, conferenceEvent.Location);
+        Assert.Equal(conferenceEventModel.Name, conferenceEvent.Name);
+        Assert.Equal(conferenceEventModel.StartDateTime, conferenceEvent.StartDateTime);
+        Assert.Equal(conferenceEventModel.Type, conferenceEvent.Type);
+    }
+}

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Services/ConferenceEventsServiceTest.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Services/ConferenceEventsServiceTest.cs
@@ -1,0 +1,615 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using Moq;
+using PaTsa.Conference.App.Api.UnitTests.Data;
+using PaTsa.Conference.App.Api.UnitTests.ExtensionMethods;
+using PaTsa.Conference.App.Api.UnitTests.Helpers;
+using PaTsa.Conference.App.Api.WebApi.Configuration;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+using PaTsa.Conference.App.Api.WebApi.Services;
+using Xunit;
+
+namespace PaTsa.Conference.App.Api.UnitTests.WebApi.Services;
+
+[ExcludeFromCodeCoverage]
+public class ConferenceEventsServiceTest
+{
+    private const string CollectionName = "conference-events";
+    private const string DatabaseName = "conference-app-cosmosdb";
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Collection_Name_Should_Be_ConferenceEvents()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object);
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        // Act
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Assert
+        Assert.Equal("conference-events", conferenceEventsService.CollectionName);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Constructor_Should_Instantiate_Base_Class()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object);
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        // Act
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Assert
+        Assert.NotNull(conferenceEventsService);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void CreateAsync_Should_Insert_New_Entity()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var conferenceEvent =
+            conferenceEventsTestData.First(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)[0] as ConferenceEvent;
+
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object)
+            .Verifiable();
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        await conferenceEventsService.CreateAsync(conferenceEvent!);
+
+        // Assert
+        mockedMongoCollection
+            .Verify(_ =>
+                _.InsertOneAsync(It.Is(conferenceEvent, new ConferenceEventEqualityComparer())!, null, CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void ExistsAsync_Should_Return_True()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var expectedConferenceEvent = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .Last();
+
+        var conferenceEvents = new List<ConferenceEvent>
+        {
+            expectedConferenceEvent
+        };
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<ConferenceEvent>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(conferenceEvents);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        var filterDefinitionJson = Builders<ConferenceEvent>.Filter.Eq(_ => _.Id, expectedConferenceEvent.Id).RenderToJson();
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                It.Is<FilterDefinition<ConferenceEvent>>(filter => filter.RenderToJson().Equals(filterDefinitionJson)),
+                It.IsAny<FindOptions<ConferenceEvent, ConferenceEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await conferenceEventsService.ExistsAsync(expectedConferenceEvent.Id!);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetAsync_Should_Get_All_Entities()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var conferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .ToList();
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<ConferenceEvent>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(conferenceEvents);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                Builders<ConferenceEvent>.Filter.Empty,
+                It.IsAny<FindOptions<ConferenceEvent, ConferenceEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await conferenceEventsService.GetAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Equal(conferenceEvents.Count, result.Count);
+        Assert.Equal(conferenceEvents, result, new ConferenceEventEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetAsync_Should_Get_Entity_By_Id()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var expectedConferenceEvent = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .Last();
+
+        var conferenceEvents = new List<ConferenceEvent>
+        {
+            expectedConferenceEvent
+        };
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<ConferenceEvent>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(conferenceEvents);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        var filterDefinitionJson = Builders<ConferenceEvent>.Filter.Eq(_ => _.Id, expectedConferenceEvent.Id).RenderToJson();
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                It.Is<FilterDefinition<ConferenceEvent>>(filter => filter.RenderToJson().Equals(filterDefinitionJson)),
+                It.IsAny<FindOptions<ConferenceEvent, ConferenceEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await conferenceEventsService.GetAsync(expectedConferenceEvent.Id!);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedConferenceEvent, result, new ConferenceEventEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetAsync_Should_Get_Entity_By_Ids()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var expectedConferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .ToList();
+
+        var ids = expectedConferenceEvents.Select(_ => _.Id).Cast<string>().ToList();
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<ConferenceEvent>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(expectedConferenceEvents);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        var filterDefinitionJson = Builders<ConferenceEvent>.Filter.In(_ => _.Id, ids).RenderToJson();
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                It.Is<FilterDefinition<ConferenceEvent>>(filter => filter.RenderToJson().Equals(filterDefinitionJson)),
+                It.IsAny<FindOptions<ConferenceEvent, ConferenceEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await conferenceEventsService.GetAsync(ids);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedConferenceEvents.Count, result.Count);
+        Assert.Equal(expectedConferenceEvents, result, new ConferenceEventEqualityComparer());
+    }
+
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Ping_Should_Return_False()
+    {
+        // Arrange
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await conferenceEventsService.PingAsync();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Ping_Should_Return_True()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+
+        mockedMongoCollection
+            .Setup(_ => _.Database)
+            .Returns(mockedMongoDatabase.Object);
+
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await conferenceEventsService.PingAsync();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void RemoveAsync_Should_Delete_Entity_By_Id()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var expectedConferenceEvent = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .Last();
+
+        var expectedFilterDefinitionJson = Builders<ConferenceEvent>.Filter.Eq(_ => _.Id, expectedConferenceEvent.Id).RenderToJson();
+
+        Func<FilterDefinition<ConferenceEvent>, bool> validateFilterDefinitionFunc = filterDefinition =>
+        {
+            var filterDefinitionJson = filterDefinition.RenderToJson();
+
+            return expectedFilterDefinitionJson == filterDefinitionJson;
+        };
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        await conferenceEventsService.RemoveAsync(expectedConferenceEvent);
+
+        // Assert
+        mockedMongoCollection
+            .Verify(_ => _.DeleteOneAsync(
+                    It.Is<FilterDefinition<ConferenceEvent>>(fd => validateFilterDefinitionFunc(fd)),
+                    null,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ServiceName_Name_Should_Be_ConferenceEvents()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object);
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        // Act
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Assert
+        Assert.Equal("ConferenceEvents", conferenceEventsService.ServiceName);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void UpdateAsync_Should_Replace_Entity_By_Id()
+    {
+        // Arrange
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var expectedConferenceEvent = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .Last();
+
+        var expectedFilterDefinitionJson = Builders<ConferenceEvent>.Filter.Eq(_ => _.Id, expectedConferenceEvent.Id).RenderToJson();
+
+        Func<FilterDefinition<ConferenceEvent>, bool> validateFilterDefinitionFunc = filterDefinition =>
+        {
+            var filterDefinitionJson = filterDefinition.RenderToJson();
+
+            return expectedFilterDefinitionJson == filterDefinitionJson;
+        };
+
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        await conferenceEventsService.UpdateAsync(expectedConferenceEvent, default);
+
+        // Assert
+        mockedMongoCollection
+            .Verify(_ => _.ReplaceOneAsync(
+                    It.Is<FilterDefinition<ConferenceEvent>>(fd => validateFilterDefinitionFunc(fd)),
+                    expectedConferenceEvent,
+                    It.IsAny<ReplaceOptions>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+    }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Configuration/ConferenceDatabase.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Configuration/ConferenceDatabase.cs
@@ -1,0 +1,10 @@
+﻿// If the values are null, that means the app was miss configured
+// If the app was miss configured, let the error bubble up
+
+#pragma warning disable CS8618
+namespace PaTsa.Conference.App.Api.WebApi.Configuration;
+
+public class ConferenceDatabase
+{
+    public string DatabaseName { get; set; }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Configuration/ConfigurationKeys.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Configuration/ConfigurationKeys.cs
@@ -1,0 +1,8 @@
+﻿namespace PaTsa.Conference.App.Api.WebApi.Configuration;
+
+public static class ConfigurationKeys
+{
+    public const string MongoDbConnectionString = "MongoDb";
+
+    public const string SubmissionsDatabaseSection = "ConferenceDatabase";
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Controllers/ConferenceEventsController.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Controllers/ConferenceEventsController.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+using PaTsa.Conference.App.Api.WebApi.Models;
+using PaTsa.Conference.App.Api.WebApi.Services;
+
+namespace PaTsa.Conference.App.Api.WebApi.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Produces("application/json")]
+public class ConferenceEventsController : ControllerBase
+{
+    private readonly IConferenceEventsService _conferenceEventsService;
+
+    public ConferenceEventsController(IConferenceEventsService conferenceEventsService)
+    {
+        _conferenceEventsService = conferenceEventsService;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<IList<ConferenceEventModel>>> Get(int pageNumber = 1, int pageSize = 25, CancellationToken cancellationToken = default)
+    {
+        var entities = await _conferenceEventsService.GetAsync(cancellationToken);
+
+        //TODO: Evaluate performance and remediate as necessary
+        return entities.Count == 0
+            ? new List<ConferenceEventModel>(0)
+            : entities
+                .ToModels()
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+    }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Entities/ConferenceEvent.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Entities/ConferenceEvent.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace PaTsa.Conference.App.Api.WebApi.Entities;
+
+public class ConferenceEvent : IMongoDbEntity
+{
+    public string? Description { get; set; }
+
+    public DateTime EndDateTime { get; set; }
+
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string? Id { get; set; }
+
+    public string? Location { get; set; }
+
+    public string? Name { get; set; }
+
+    public DateTime StartDateTime { get; set; }
+
+    public string? Type { get; set; }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Entities/EntityExtensions.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Entities/EntityExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using PaTsa.Conference.App.Api.WebApi.Models;
+
+namespace PaTsa.Conference.App.Api.WebApi.Entities;
+
+public static class EntityExtensions
+{
+    public static ConferenceEventModel ToModel(this ConferenceEvent conferenceEvent)
+    {
+        return new ConferenceEventModel
+        {
+            Description = conferenceEvent.Description,
+            EndDateTime = conferenceEvent.EndDateTime,
+            Id = conferenceEvent.Id,
+            Location = conferenceEvent.Location,
+            Name = conferenceEvent.Name,
+            StartDateTime = conferenceEvent.StartDateTime,
+            Type = conferenceEvent.Type
+        };
+    }
+
+    public static List<ConferenceEventModel> ToModels(this IList<ConferenceEvent> conferenceEvents)
+    {
+        return conferenceEvents.Select(conferenceEvent => conferenceEvent.ToModel()).ToList();
+    }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Entities/IMongoDbEntity.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Entities/IMongoDbEntity.cs
@@ -1,0 +1,6 @@
+﻿namespace PaTsa.Conference.App.Api.WebApi.Entities;
+
+public interface IMongoDbEntity
+{
+    string? Id { get; set; }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Models/ConferenceEventModel.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Models/ConferenceEventModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace PaTsa.Conference.App.Api.WebApi.Models;
+
+public class ConferenceEventModel
+{
+    public string? Description { get; set; }
+
+    public DateTime EndDateTime { get; set; }
+
+    public string? Id { get; set; }
+
+    public string? Location { get; set; }
+
+    public string? Name { get; set; }
+
+    public DateTime StartDateTime { get; set; }
+
+    public string? Type { get; set; }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Models/ModelExtensions.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Models/ModelExtensions.cs
@@ -1,0 +1,20 @@
+﻿using PaTsa.Conference.App.Api.WebApi.Entities;
+
+namespace PaTsa.Conference.App.Api.WebApi.Models;
+
+public static class ModelExtensions
+{
+    public static ConferenceEvent ToEntity(this ConferenceEventModel conferenceEventModel)
+    {
+        return new ConferenceEvent
+        {
+            Description = conferenceEventModel.Description,
+            EndDateTime = conferenceEventModel.EndDateTime,
+            Id = conferenceEventModel.Id,
+            Location = conferenceEventModel.Location,
+            Name = conferenceEventModel.Name,
+            StartDateTime = conferenceEventModel.StartDateTime,
+            Type = conferenceEventModel.Type
+        };
+    }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Models/ServicesStatusModel.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Models/ServicesStatusModel.cs
@@ -1,6 +1,19 @@
-﻿namespace PaTsa.Conference.App.Api.WebApi.Models;
+﻿using System.Linq;
+
+namespace PaTsa.Conference.App.Api.WebApi.Models;
 
 public class ServicesStatusModel
 {
-    public bool IsHealthy => true;
+    public bool ConferenceEventsServiceIsAlive { get; set; }
+
+    public bool IsHealthy => EvaluateIsHealthy();
+
+    private bool EvaluateIsHealthy()
+    {
+        var propertyInfos = GetType().GetProperties().Where(_ => _.CanWrite && _.PropertyType == typeof(bool));
+
+        var isAliveList = propertyInfos.Select(propertyInfo => (bool)propertyInfo.GetValue(this)!).ToList();
+
+        return isAliveList.All(isAlive => isAlive);
+    }
 }

--- a/src/PaTsa.Conference.App.Api.WebApi/PaTsa.Conference.App.Api.WebApi.csproj
+++ b/src/PaTsa.Conference.App.Api.WebApi/PaTsa.Conference.App.Api.WebApi.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />

--- a/src/PaTsa.Conference.App.Api.WebApi/Services/ConferenceEventsService.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Services/ConferenceEventsService.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using PaTsa.Conference.App.Api.WebApi.Configuration;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+
+namespace PaTsa.Conference.App.Api.WebApi.Services;
+
+public class ConferenceEventsService : MongoDbService<ConferenceEvent>, IConferenceEventsService
+{
+    public const string MongoDbCollectionName = "conference-events";
+
+    public string CollectionName => MongoDbCollectionName;
+
+    public string ServiceName => "ConferenceEvents";
+
+    public ConferenceEventsService(IMongoClient mongoClient, IOptions<ConferenceDatabase> options) : base(
+        mongoClient,
+        options.Value.DatabaseName,
+        MongoDbCollectionName)
+    { }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Services/IConferenceEventsService.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Services/IConferenceEventsService.cs
@@ -1,0 +1,5 @@
+﻿using PaTsa.Conference.App.Api.WebApi.Entities;
+
+namespace PaTsa.Conference.App.Api.WebApi.Services;
+
+public interface IConferenceEventsService : IMongoEntityService<ConferenceEvent>, IPingableService { }

--- a/src/PaTsa.Conference.App.Api.WebApi/Services/IMongoEntityService.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Services/IMongoEntityService.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PaTsa.Conference.App.Api.WebApi.Services;
+
+public interface IMongoEntityService<T>
+{
+    string CollectionName { get; }
+
+    Task CreateAsync(T entity, CancellationToken cancellationToken = default);
+
+    Task<bool> ExistsAsync(string id, CancellationToken cancellationToken = default);
+
+    Task<List<T>> GetAsync(CancellationToken cancellationToken = default);
+
+    Task<List<T>> GetAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default);
+
+    Task<T?> GetAsync(string id, CancellationToken cancellationToken = default);
+
+    Task RemoveAsync(T entity, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(T entity, CancellationToken cancellationToken = default);
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Services/MongoDbService.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Services/MongoDbService.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using PaTsa.Conference.App.Api.WebApi.Entities;
+
+namespace PaTsa.Conference.App.Api.WebApi.Services;
+
+public abstract class MongoDbService<T> where T : IMongoDbEntity
+{
+    protected IMongoCollection<T> EntityCollection;
+    protected IMongoDatabase MongoDatabase;
+
+    protected MongoDbService(IMongoClient mongoClient, string databaseName, string collectionName)
+    {
+        MongoDatabase = mongoClient.GetDatabase(databaseName);
+
+        EntityCollection = MongoDatabase.GetCollection<T>(collectionName);
+    }
+
+    public async Task CreateAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        await EntityCollection.InsertOneAsync(entity, null, cancellationToken);
+    }
+
+    public async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var filterDefinition = Builders<T>.Filter.Eq(_ => _.Id, id);
+
+        var cursor = await EntityCollection.FindAsync(filterDefinition, null, cancellationToken);
+
+        return await cursor.AnyAsync(cancellationToken);
+    }
+
+    public async Task<List<T>> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var cursor = await EntityCollection.FindAsync(Builders<T>.Filter.Empty, null, cancellationToken);
+
+        var result = await cursor.ToListAsync(cancellationToken);
+
+        return result;
+    }
+
+    public async Task<List<T>> GetAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+    {
+        var filterDefinition = Builders<T>.Filter.In(_ => _.Id, ids);
+
+        var cursor = await EntityCollection.FindAsync(filterDefinition, null, cancellationToken);
+
+        var result = await cursor.ToListAsync(cancellationToken);
+
+        return result;
+    }
+
+    public async Task<T?> GetAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var filterDefinition = Builders<T>.Filter.Eq(_ => _.Id, id);
+
+        var cursor = await EntityCollection.FindAsync(filterDefinition, null, cancellationToken);
+
+        var result = await cursor.FirstOrDefaultAsync(cancellationToken);
+
+        return result;
+    }
+
+    public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
+    {
+        var successful = true;
+
+        try
+        {
+            await EntityCollection.Database.RunCommandAsync((Command<BsonDocument>)"{ping:1}", cancellationToken: cancellationToken);
+        }
+        catch (Exception)
+        {
+            successful = false;
+        }
+
+        return successful;
+    }
+
+    public async Task RemoveAsync(T entity, CancellationToken cancellationToken = default)
+    {
+        var filterDefinition = Builders<T>.Filter.Eq(_ => _.Id, entity.Id);
+
+        await EntityCollection.DeleteOneAsync(filterDefinition, null, cancellationToken);
+    }
+
+    public async Task UpdateAsync(T entity, CancellationToken cancellationToken)
+    {
+        var filterDefinition = Builders<T>.Filter.Eq(_ => _.Id, entity.Id);
+
+        var replaceOptions = new ReplaceOptions
+        {
+            IsUpsert = false
+        };
+
+        await EntityCollection.ReplaceOneAsync(filterDefinition, entity, replaceOptions, cancellationToken);
+    }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Startup.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using PaTsa.Conference.App.Api.WebApi.Middleware;
+using PaTsa.Conference.App.Api.WebApi.Services;
 using PaTsa.Conference.App.Api.WebApi.Swagger;
 
 namespace PaTsa.Conference.App.Api.WebApi
@@ -46,11 +47,11 @@ namespace PaTsa.Conference.App.Api.WebApi
         {
             //services.Configure<PointOfSalesDatabase>(Configuration.GetSection(ConfigurationKeys.ConferenceDatabaseSection));
 
-            // Injectable Services
-
-            // Cosmos DB Services
+            // MongoDB Services
+            services.AddSingleton<IConferenceEventsService, ConferenceEventsService>();
 
             // Pingable Services - Should match MongoDB Services
+            services.AddSingleton<IPingableService, ConferenceEventsService>();
 
             // Validators;
 

--- a/terraform/cosmos_db.tf
+++ b/terraform/cosmos_db.tf
@@ -26,10 +26,10 @@ resource "azurerm_cosmosdb_account" "pa_tsa_conference_cosmosdb" {
   }
 }
 
-resource "azurerm_cosmosdb_mongo_collection" "schedule_collection" {
+resource "azurerm_cosmosdb_mongo_collection" "conference_events_collection" {
   account_name        = azurerm_cosmosdb_account.pa_tsa_conference_cosmosdb.name
   database_name       = azurerm_cosmosdb_mongo_database.conference_app_cosmosdb.name
-  name                = "schedule"
+  name                = "conference-events"
   resource_group_name = azurerm_resource_group.pa_tsa_conference_app_api_rg.name
 }
 


### PR DESCRIPTION
## Summary
This PR implements the `HTTP GET` endpoint for the Conference Event API. It pages the result set by default with the ability for the consumer to adjust as needed. At the moment, no max limit is needed as this is more for the mobile app.

The pagination could be improved by moving it to the MongoDB query but that may not be needed. I'm waiting for a need to implement this.