### PR TITLE
Fixing Workflow Permissions

### DIFF
--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -7,6 +7,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   gitVersionJob:
     name: CD - GitVersion Workflow
@@ -29,8 +32,6 @@ jobs:
   tagRepoJob:
     name: CD - Tag Repo Workflow
     needs: [buildApplicationJob, terraformApplyJob]
-    permissions:
-      contents: write
     uses: ./.github/workflows/tag-repo-reusable-workflow.yml
     with:
       semVer: ${{ needs.gitVersionJob.outputs.semVer }}

--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -28,7 +28,9 @@ jobs:
 
   tagRepoJob:
     name: CD - Tag Repo Workflow
-    needs: gitVersionJob
+    needs: [buildApplicationJob, terraformApplyJob]
+    permissions:
+      contents: write
     uses: ./.github/workflows/tag-repo-reusable-workflow.yml
     with:
       semVer: ${{ needs.gitVersionJob.outputs.semVer }}

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -8,6 +8,10 @@ on:
       - 'src/**'
       - 'terraform/**'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   gitVersionJob:
     name: PR - GitVersion Workflow
@@ -16,9 +20,6 @@ jobs:
   buildApplicationJob:
     name: PR - Build Workflow
     needs: gitVersionJob
-    permissions:
-      issues: write
-      pull-requests: write
     uses: ./.github/workflows/build-reusable-workflow.yml
     with:
       semVer: ${{ needs.gitVersionJob.outputs.semVer }}

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -8,10 +8,6 @@ on:
       - 'src/**'
       - 'terraform/**'
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   gitVersionJob:
     name: PR - GitVersion Workflow
@@ -20,6 +16,9 @@ jobs:
   buildApplicationJob:
     name: PR - Build Workflow
     needs: gitVersionJob
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/build-reusable-workflow.yml
     with:
       semVer: ${{ needs.gitVersionJob.outputs.semVer }}


### PR DESCRIPTION
Address issue with tagging repo
Increases security by granting specific jobs the permissions