### PR TITLE
Fixe Create Tag Workflow

### DIFF
--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -31,7 +31,7 @@ jobs:
 
   tagRepoJob:
     name: CD - Tag Repo Workflow
-    needs: [buildApplicationJob, terraformApplyJob]
+    needs: [gitVersionJob, buildApplicationJob, terraformApplyJob]
     uses: ./.github/workflows/tag-repo-reusable-workflow.yml
     with:
       semVer: ${{ needs.gitVersionJob.outputs.semVer }}


### PR DESCRIPTION
Added a missing `needs` to the `tagRepoJob` so it can access the outputs of `gitVersionJob`.