### PR TITLE
Implement Event Types Filtering

### DIFF
--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/ConferenceEventsControllerTests.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Controllers/ConferenceEventsControllerTests.cs
@@ -43,7 +43,7 @@ public class ConferenceEventsControllerTests
         var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
 
         // Act
-        var actionResult = await conferenceEventsController.Get(pageNumber, pageSize);
+        var actionResult = await conferenceEventsController.Get(null, pageNumber, pageSize);
 
         Assert.NotNull(actionResult);
 
@@ -164,7 +164,7 @@ public class ConferenceEventsControllerTests
         var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
 
         // Act
-        var actionResult = await conferenceEventsController.Get();
+        var actionResult = await conferenceEventsController.Get(null);
 
         Assert.NotNull(actionResult);
 
@@ -194,7 +194,44 @@ public class ConferenceEventsControllerTests
         var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
 
         // Act
-        var actionResult = await conferenceEventsController.Get();
+        var actionResult = await conferenceEventsController.Get(null);
+
+        Assert.NotNull(actionResult);
+
+        var conferenceEventModels = actionResult.Value;
+        Assert.NotNull(conferenceEventModels);
+        Assert.NotEmpty(conferenceEventModels);
+        Assert.Equal(25, conferenceEventModels.Count);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_With_Default_PageNumber_And_PageSize_When_Filtered()
+    {
+        // Arrange
+        var typesList = new List<string> { "Middle School", "High School", "Special Interest" };
+
+        var types = string.Join(',', typesList);
+
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var conferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .ToList();
+
+        Func<IEnumerable<string>, bool> validateFilter = filters => { return filters.All(filter => typesList.Contains(filter)); };
+
+        var mockedConferenceEventsService = new Mock<IConferenceEventsService>();
+        mockedConferenceEventsService
+            .Setup(_ => _.FilterAsync(It.Is<IEnumerable<string>>(f => validateFilter(f)), default))
+            .ReturnsAsync(conferenceEvents);
+
+        var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
+
+        // Act
+        var actionResult = await conferenceEventsController.Get(types);
 
         Assert.NotNull(actionResult);
 
@@ -238,7 +275,7 @@ public class ConferenceEventsControllerTests
         var conferenceEventsController = new ConferenceEventsController(mockedConferenceEventsService.Object);
 
         // Act
-        var actionResult = await conferenceEventsController.Get(pageNumber, pageSize);
+        var actionResult = await conferenceEventsController.Get(null, pageNumber, pageSize);
 
         Assert.NotNull(actionResult);
 

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Services/ConferenceEventsServiceTest.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Services/ConferenceEventsServiceTest.cs
@@ -196,6 +196,88 @@ public class ConferenceEventsServiceTest
         Assert.True(result);
     }
 
+    [Theory]
+    [InlineData("Middle School")]
+    [InlineData("Middle School","High School")]
+    [InlineData("Middle School", "Special Interest")]
+    [InlineData("Middle School", "High School", "Special Interest")]
+    [InlineData("High School", "Special Interest")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void FilterAsync_Should_Filter_Entities_By_Type(params string[] types)
+    {
+        // Arrange
+        Func<ConferenceEvent, bool> predicate = p => p.Type == types[0];
+
+        for (var index = 1; index < types.Length; index++)
+        {
+            var oldPredicate = predicate;
+            var value = types[index];
+            // ReSharper disable once AccessToModifiedClosure
+            predicate = p => oldPredicate(p) || p.Type == value;
+        }
+
+        var conferenceEventsTestData = new ConferenceEventsTestData();
+
+        var expectedConferenceEvents = conferenceEventsTestData
+            .Where(_ => (ConferenceEventDataIssues)_[1] == ConferenceEventDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<ConferenceEvent>()
+            .Where(predicate)
+            .ToList();
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<ConferenceEvent>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(expectedConferenceEvents);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        var eventTypes = types.Select(type => Builders<ConferenceEvent>.Filter.Eq(_ => _.Type, type)).ToList();
+
+        var filterDefinitionJson = Builders<ConferenceEvent>.Filter.Or(eventTypes).RenderToJson();
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<ConferenceEvent>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                It.Is<FilterDefinition<ConferenceEvent>>(filter => filter.RenderToJson().Equals(filterDefinitionJson)),
+                It.IsAny<FindOptions<ConferenceEvent, ConferenceEvent>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<ConferenceEvent>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<ConferenceDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new ConferenceDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var conferenceEventsService = new ConferenceEventsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await conferenceEventsService.FilterAsync(types);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedConferenceEvents.Count, result.Count);
+        Assert.Equal(expectedConferenceEvents, result, new ConferenceEventEqualityComparer());
+    }
+
     [Fact]
     [Trait("TestCategory", "UnitTest")]
     public async void GetAsync_Should_Get_All_Entities()

--- a/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Services/ConferenceEventsServiceTest.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/WebApi/Services/ConferenceEventsServiceTest.cs
@@ -198,7 +198,7 @@ public class ConferenceEventsServiceTest
 
     [Theory]
     [InlineData("Middle School")]
-    [InlineData("Middle School","High School")]
+    [InlineData("Middle School", "High School")]
     [InlineData("Middle School", "Special Interest")]
     [InlineData("Middle School", "High School", "Special Interest")]
     [InlineData("High School", "Special Interest")]

--- a/src/PaTsa.Conference.App.Api.WebApi/Models/ModelExtensions.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Models/ModelExtensions.cs
@@ -4,13 +4,13 @@ namespace PaTsa.Conference.App.Api.WebApi.Models;
 
 public static class ModelExtensions
 {
-    public static ConferenceEvent ToEntity(this ConferenceEventModel conferenceEventModel)
+    public static ConferenceEvent ToEntity(this ConferenceEventModel conferenceEventModel, bool ignoreId = false)
     {
         return new ConferenceEvent
         {
             Description = conferenceEventModel.Description,
             EndDateTime = conferenceEventModel.EndDateTime,
-            Id = conferenceEventModel.Id,
+            Id = ignoreId ? null : conferenceEventModel.Id,
             Location = conferenceEventModel.Location,
             Name = conferenceEventModel.Name,
             StartDateTime = conferenceEventModel.StartDateTime,

--- a/src/PaTsa.Conference.App.Api.WebApi/Services/ConferenceEventsService.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Services/ConferenceEventsService.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Extensions.Options;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using PaTsa.Conference.App.Api.WebApi.Configuration;
 using PaTsa.Conference.App.Api.WebApi.Entities;
@@ -18,4 +22,17 @@ public class ConferenceEventsService : MongoDbService<ConferenceEvent>, IConfere
         options.Value.DatabaseName,
         MongoDbCollectionName)
     { }
+
+    public async Task<List<ConferenceEvent>> FilterAsync(IEnumerable<string> types, CancellationToken cancellationToken = default)
+    {
+        var eventTypes = types.Select(type => Builders<ConferenceEvent>.Filter.Eq(_ => _.Type, type)).ToList();
+
+        var filterDefinitions = Builders<ConferenceEvent>.Filter.Or(eventTypes);
+
+        var cursor = await EntityCollection.FindAsync(filterDefinitions, null, cancellationToken);
+
+        var result = await cursor.ToListAsync(cancellationToken);
+
+        return result;
+    }
 }

--- a/src/PaTsa.Conference.App.Api.WebApi/Services/IConferenceEventsService.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Services/IConferenceEventsService.cs
@@ -1,5 +1,11 @@
 ﻿using PaTsa.Conference.App.Api.WebApi.Entities;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PaTsa.Conference.App.Api.WebApi.Services;
 
-public interface IConferenceEventsService : IMongoEntityService<ConferenceEvent>, IPingableService { }
+public interface IConferenceEventsService : IMongoEntityService<ConferenceEvent>, IPingableService
+{
+    Task<List<ConferenceEvent>> FilterAsync(IEnumerable<string> types, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary
This change allows the consumer of the API to filter the events that come back using the query string parameter `types`. This is a CSV of event types that is split into an `IEnumerable<string>` and passed into the new `ConferenceEventsService.FilterAsync` method. This method dynamically creates  a MongoDB filter definition and then is passed onto Cosmos DB as a query. This reduces the CPU and memory needs of the web app and allows Cosmos DB to do what it does best.