### PR TITLE
Added Ability to Update a Conference Event

### DIFF
--- a/src/PaTsa.Conference.App.Api.UnitTests/Helpers/StringEqualityComparer.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/Helpers/StringEqualityComparer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PaTsa.Conference.App.Api.UnitTests.Helpers;
+
+[ExcludeFromCodeCoverage]
+internal class StringEqualityComparer : IEqualityComparer<string?>
+{
+    public bool Equals(string? x, string? y)
+    {
+        return string.Equals(x, y, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    public int GetHashCode(string? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
+    }
+}

--- a/src/PaTsa.Conference.App.Api.WebApi/Controllers/ConferenceEventsController.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Controllers/ConferenceEventsController.cs
@@ -23,6 +23,18 @@ public class ConferenceEventsController : ControllerBase
         _conferenceEventsService = conferenceEventsService;
     }
 
+    [HttpGet("{id:length(24)}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ConferenceEventModel))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ConferenceEventModel>> Get(string id, CancellationToken cancellationToken = default)
+    {
+        var conferenceEvent = await _conferenceEventsService.GetAsync(id, cancellationToken);
+
+        if (conferenceEvent == null) return NotFound();
+
+        return conferenceEvent.ToModel();
+    }
+
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IList<ConferenceEventModel>>> Get(
@@ -57,5 +69,22 @@ public class ConferenceEventsController : ControllerBase
         conferenceEventModel.Id = conferenceEvent.Id;
 
         return CreatedAtAction(nameof(Get), new { id = conferenceEvent.Id }, conferenceEventModel);
+    }
+
+    [HttpPut("{id:length(24)}")]
+    [ApiKeyAuthorization]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Put(string id, ConferenceEventModel updatedConferenceEventModel, CancellationToken cancellationToken = default)
+    {
+        var conferenceEvent = await _conferenceEventsService.GetAsync(id, cancellationToken);
+
+        if (conferenceEvent == null) return NotFound();
+
+        updatedConferenceEventModel.Id = conferenceEvent.Id;
+
+        await _conferenceEventsService.UpdateAsync(updatedConferenceEventModel.ToEntity(), cancellationToken);
+
+        return NoContent();
     }
 }


### PR DESCRIPTION
## Summary
Added ability to update an existing conference event. In addition, I added the ability to fetch a single event which makes testing this easier but also will likely be needed at some point. Unit tests were updated to add coverage as necessary. In addition, a new unit test was added to ensure that any data modifying REST operation has the `ApiKeyAuthorization` attribute to ensure only authenticated users are modifying the data.