### PR TITLE
Added EventId

### DIFF
--- a/src/PaTsa.Conference.App.Api.UnitTests/Helpers/ConferenceEventEqualityComparer.cs
+++ b/src/PaTsa.Conference.App.Api.UnitTests/Helpers/ConferenceEventEqualityComparer.cs
@@ -16,6 +16,7 @@ internal class ConferenceEventEqualityComparer : IEqualityComparer<ConferenceEve
 
         var descriptionsMatch = x.Description == y.Description;
         var endDateTimesMatch = x.EndDateTime == y.EndDateTime;
+        var eventIdsMatch = x.EventId == y.EventId;
         var idsMatch = x.Id == y.Id;
         var locationsMatch = x.Location == y.Location;
         var namesMatch = x.Name == y.Name;
@@ -24,6 +25,7 @@ internal class ConferenceEventEqualityComparer : IEqualityComparer<ConferenceEve
 
         return descriptionsMatch &&
                endDateTimesMatch &&
+               eventIdsMatch &&
                idsMatch &&
                locationsMatch &&
                namesMatch &&

--- a/src/PaTsa.Conference.App.Api.WebApi/Entities/ConferenceEvent.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Entities/ConferenceEvent.cs
@@ -10,6 +10,8 @@ public class ConferenceEvent : IMongoDbEntity
 
     public DateTime EndDateTime { get; set; }
 
+    public string? EventId { get; set; }
+
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
     public string? Id { get; set; }

--- a/src/PaTsa.Conference.App.Api.WebApi/Entities/EntityExtensions.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Entities/EntityExtensions.cs
@@ -12,6 +12,7 @@ public static class EntityExtensions
         {
             Description = conferenceEvent.Description,
             EndDateTime = conferenceEvent.EndDateTime,
+            EventId = conferenceEvent.EventId,
             Id = conferenceEvent.Id,
             Location = conferenceEvent.Location,
             Name = conferenceEvent.Name,

--- a/src/PaTsa.Conference.App.Api.WebApi/Models/ConferenceEventModel.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Models/ConferenceEventModel.cs
@@ -8,6 +8,8 @@ public class ConferenceEventModel
 
     public DateTime EndDateTime { get; set; }
 
+    public string? EventId { get; set; }
+
     public string? Id { get; set; }
 
     public string? Location { get; set; }

--- a/src/PaTsa.Conference.App.Api.WebApi/Models/ModelExtensions.cs
+++ b/src/PaTsa.Conference.App.Api.WebApi/Models/ModelExtensions.cs
@@ -10,6 +10,7 @@ public static class ModelExtensions
         {
             Description = conferenceEventModel.Description,
             EndDateTime = conferenceEventModel.EndDateTime,
+            EventId = conferenceEventModel.EventId,
             Id = ignoreId ? null : conferenceEventModel.Id,
             Location = conferenceEventModel.Location,
             Name = conferenceEventModel.Name,


### PR DESCRIPTION
## Summary
Added a property called `EventId` which is needed by the mobile application. This property uniquely identifies a competition and not an event. This allows the mobile application to filter or favorite a competition regardless of the time.